### PR TITLE
chore: clean dashboard logs and fix image upload reset

### DIFF
--- a/veneburger-dashboard/src/components/common/ImageUpload.tsx
+++ b/veneburger-dashboard/src/components/common/ImageUpload.tsx
@@ -1,5 +1,5 @@
 // src/components/common/ImageUpload.tsx
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { 
   Box, 
   Typography, 
@@ -29,6 +29,7 @@ const ImageUpload = ({
 }: ImageUploadProps) => {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   
   // Al iniciar o cuando cambia initialImage, actualizar la vista previa
   useEffect(() => {
@@ -85,12 +86,11 @@ const ImageUpload = ({
       onImageChange(null);
       
       // Resetear el campo de entrada
-      const fileInput = document.getElementById('image-upload-input') as HTMLInputElement;
-      if (fileInput) {
-        fileInput.value = '';
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
       }
     } catch (error) {
-      console.error('Error al eliminar la imagen:', error);
+      alert('No se pudo eliminar la imagen.');
     } finally {
       setIsLoading(false);
     }
@@ -160,7 +160,7 @@ const ImageUpload = ({
       >
         Seleccionar Imagen
         <input
-          id="image-upload-input"
+          ref={fileInputRef}
           type="file"
           accept="image/*"
           onChange={handleFileChange}

--- a/veneburger-dashboard/src/pages/admin/Dashboard.jsx
+++ b/veneburger-dashboard/src/pages/admin/Dashboard.jsx
@@ -66,7 +66,6 @@ const Dashboard = () => {
       setVentasDiarias(response.data.data);
     } catch (error) {
       setErrorDaily(error.response?.data?.message || 'Error al cargar ventas diarias');
-      console.error('Error al cargar ventas diarias:', error);
     } finally {
       setLoadingDaily(false);
     }
@@ -83,7 +82,6 @@ const Dashboard = () => {
       setVentasMensuales(response.data.data);
     } catch (error) {
       setErrorMonthly(error.response?.data?.message || 'Error al cargar ventas mensuales');
-      console.error('Error al cargar ventas mensuales:', error);
     } finally {
       setLoadingMonthly(false);
     }
@@ -102,7 +100,6 @@ const Dashboard = () => {
       setProductosMasVendidos(response.data.data);
     } catch (error) {
       setErrorProducts(error.response?.data?.message || 'Error al cargar productos más vendidos');
-      console.error('Error al cargar productos más vendidos:', error);
     } finally {
       setLoadingProducts(false);
     }
@@ -121,7 +118,6 @@ const Dashboard = () => {
       setVentasPorTipo(response.data.data);
     } catch (error) {
       setErrorTypes(error.response?.data?.message || 'Error al cargar ventas por tipo');
-      console.error('Error al cargar ventas por tipo:', error);
     } finally {
       setLoadingTypes(false);
     }

--- a/veneburger-dashboard/src/pages/admin/products/ProductForm.tsx
+++ b/veneburger-dashboard/src/pages/admin/products/ProductForm.tsx
@@ -65,12 +65,10 @@ const ProductForm = () => {
       if (response.data && response.data.data && Array.isArray(response.data.data.categorias)) {
         setCategories(response.data.data.categorias);
       } else {
-        console.warn('Formato de respuesta inesperado en categorías:', response.data);
         setCategories([]);
         throw new Error('Formato de respuesta inesperado');
       }
     } catch (err) {
-      console.error('Error al cargar categorías:', err);
       setError('No se pudieron cargar las categorías. Por favor, recarga la página.');
     } finally {
       setCategoryLoading(false);
@@ -107,13 +105,11 @@ const ProductForm = () => {
         
         setInitialImage(product.imagen || null);
       } else {
-        console.warn('Formato de respuesta inesperado en producto:', response.data);
         throw new Error('No se pudo obtener la información del producto');
       }
       
       setError(null);
     } catch (err: any) {
-      console.error('Error al cargar producto:', err);
       setError(err.response?.data?.message || 'No se pudo cargar la información del producto. Por favor, intenta más tarde.');
     } finally {
       setLoading(false);
@@ -130,7 +126,7 @@ const ProductForm = () => {
       // Si hay una imagen que se removió pero no se envió el formulario, eliminarla
       if (removedImage && removedImage !== 'default.png') {
         deleteFile('productos', removedImage)
-          .catch(err => console.error('Error al eliminar imagen temporal:', err));
+          .catch(() => null);
       }
     };
   }, [removedImage]);
@@ -234,7 +230,6 @@ const ProductForm = () => {
         }
       }
     } catch (err: any) {
-      console.error('Error al guardar producto:', err);
       setError(err.response?.data?.message || err.message || 'Error al guardar el producto');
     } finally {
       setSubmitting(false);

--- a/veneburger-dashboard/src/services/uploadService.ts
+++ b/veneburger-dashboard/src/services/uploadService.ts
@@ -13,7 +13,6 @@ export const deleteFile = async (
       await api.delete(`/uploads/${type}/${filename}`);
       return true;
     } catch (error) {
-      console.error('Error al eliminar archivo:', error);
       return false;
     }
   };


### PR DESCRIPTION
## Summary
- remove stray console errors from dashboard and product form
- use ref in ImageUpload to avoid duplicate IDs and reset input safely
- drop console logging from upload service

## Testing
- `npm test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c08d5aab48832bb947238b40882d48